### PR TITLE
[Auto] Update to Minecraft 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ java_version=21
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21
-yarn_mappings=1.21+build.4
-loader_version=0.15.11
+yarn_mappings=1.21+build.9
+loader_version=0.16.0
 
 # Mod Properties
 # Note: this version number is updated during release
@@ -17,5 +17,5 @@ maven_group=co.secretonline.accessiblestep
 archives_base_name=accessible-step
 
 # Dependencies
-fabric_version=0.100.4+1.21
+fabric_version=0.100.8+1.21
 modmenu_version=11.0.1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,7 +43,7 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.15.11",
+    "fabricloader": ">=0.16.0",
     "minecraft": "1.21"
   },
   "suggests": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21` (Compatible: `1.21`)|
|Java|`21`|
|Yarn Mappings|`1.21+build.9`|
|Fabric API|`0.100.8+1.21`|
|Mod Menu|`11.0.1`|
|Fabric Loader|`0.16.0`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

