### PR TITLE
[Auto] Update to Minecraft 1.21.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ java_version=21
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21.1
-yarn_mappings=1.21.1+build.1
-loader_version=0.16.0
+yarn_mappings=1.21.1+build.3
+loader_version=0.16.7
 
 # Mod Properties
 # Note: this version number is updated during release
@@ -17,5 +17,5 @@ maven_group=co.secretonline.accessiblestep
 archives_base_name=accessible-step
 
 # Dependencies
-fabric_version=0.102.0+1.21.1
-modmenu_version=11.0.1
+fabric_version=0.106.0+1.21.1
+modmenu_version=11.0.3

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -51,7 +51,7 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.16.0",
+    "fabricloader": ">=0.16.7",
     "minecraft": "1.21.1"
   },
   "suggests": {


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.1` (Compatible: `1.21.1`)|
|Java|`21`|
|Yarn Mappings|`1.21.1+build.3`|
|Fabric API|`0.106.0+1.21.1`|
|Mod Menu|`11.0.3`|
|Fabric Loader|`0.16.7`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

