### PR TITLE
[Auto] Update to Minecraft 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ java_version=21
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.4
+minecraft_version=1.21
+yarn_mappings=1.21+build.9
 loader_version=0.16.9
 
 # Mod Properties
@@ -17,6 +17,6 @@ maven_group=co.secretonline.accessiblestep
 archives_base_name=accessible-step
 
 # Dependencies
-fabric_version=0.114.0+1.21.4
-modmenu_version=13.0.0-beta.1
+fabric_version=0.102.0+1.21
+modmenu_version=11.0.3
 jankson_version=1.2.3

--- a/src/client/resources/fabric.mod.json
+++ b/src/client/resources/fabric.mod.json
@@ -48,7 +48,7 @@
   },
   "recommends": {
     "fabricloader": ">=0.16.9",
-    "minecraft": "~1.21.2"
+    "minecraft": "1.21 - 1.21.1"
   },
   "suggests": {
     "modmenu": "*"


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21` (Compatible: `1.21 - 1.21.1`)|
|Java|`21`|
|Yarn Mappings|`1.21+build.9`|
|Fabric API|`0.102.0+1.21`|
|Mod Menu|`11.0.3`|
|Fabric Loader|`0.16.9`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

