### PR TITLE
[Auto] Update to Minecraft 1.21.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,14 +11,14 @@ archives_name=accessible-step
 enabled_platforms=fabric,neoforge
 
 # Minecraft properties
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
+minecraft_version=1.21.7
+yarn_mappings=1.21.7+build.6
 
 # Dependencies
 fabric_loader_version=0.16.14
-fabric_api_version=0.127.0+1.21.6
-neoforge_version=21.6.4-beta
+fabric_api_version=0.129.0+1.21.7
+neoforge_version=21.7.8-beta
 yarn_mappings_patch_neoforge_version=1.21+build.4
 
-modmenu_version=15.0.0-beta.2
+modmenu_version=15.0.0-beta.3
 jankson_version=1.2.3


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.7`|
|Java|`21`|
|Yarn Mappings|`1.21.7+build.6`|
|NeoForge Yarn Patch|`1.21+build.4`|
|Fabric Loader|`0.16.14`|
|Fabric API|`0.129.0+1.21.7`|
|NeoForge|`21.7.8-beta`|
|Mod Menu|`15.0.0-beta.3`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

