### PR TITLE
[Auto] Update to Minecraft 1.21.8

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -47,7 +47,7 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.16.14",
+    "fabricloader": ">=0.17.2",
     "minecraft": "~1.21.2"
   },
   "suggests": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,10 +15,10 @@ minecraft_version=1.21.8
 yarn_mappings=1.21.8+build.1
 
 # Dependencies
-fabric_loader_version=0.16.14
-fabric_api_version=0.129.0+1.21.8
-neoforge_version=21.8.2-beta
+fabric_loader_version=0.17.2
+fabric_api_version=0.133.4+1.21.8
+neoforge_version=21.8.33
 yarn_mappings_patch_neoforge_version=1.21+build.4
 
-modmenu_version=15.0.0-beta.3
+modmenu_version=15.0.0
 jankson_version=1.2.3


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.8`|
|Java|`21`|
|Yarn Mappings|`1.21.8+build.1`|
|NeoForge Yarn Patch|`1.21+build.4`|
|Fabric Loader|`0.17.2`|
|Fabric API|`0.133.4+1.21.8`|
|NeoForge|`21.8.33`|
|Mod Menu|`15.0.0`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

