### PR TITLE
[Auto] Update to Minecraft 1.21.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,9 @@ yarn_mappings=1.21.9+build.1
 
 # Dependencies
 fabric_loader_version=0.17.2
-fabric_api_version=0.133.14+1.21.9
+fabric_api_version=0.134.0+1.21.9
 neoforge_version=21.9.0-beta
 yarn_mappings_patch_neoforge_version=1.21+build.4
 
-modmenu_version=15.0.0-beta.3
+modmenu_version=16.0.0-rc.1
 jankson_version=1.2.3


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.9`|
|Java|`21`|
|Yarn Mappings|`1.21.9+build.1`|
|NeoForge Yarn Patch|`1.21+build.4`|
|Fabric Loader|`0.17.2`|
|Fabric API|`0.134.0+1.21.9`|
|NeoForge|`21.9.0-beta`|
|Mod Menu|`16.0.0-rc.1`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

