### PR TITLE
[Auto] Update to Minecraft 1.21.10

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -47,7 +47,7 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.17.2",
+    "fabricloader": ">=0.17.3",
     "minecraft": "~1.21.9"
   },
   "suggests": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,13 +11,13 @@ archives_name=accessible-step
 enabled_platforms=fabric,neoforge
 
 # Minecraft properties
-minecraft_version=1.21.9
-yarn_mappings=1.21.9+build.1
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
 
 # Dependencies
-fabric_loader_version=0.17.2
-fabric_api_version=0.134.0+1.21.9
-neoforge_version=21.9.0-beta
+fabric_loader_version=0.17.3
+fabric_api_version=0.135.0+1.21.10
+neoforge_version=21.10.6-beta
 yarn_mappings_patch_neoforge_version=1.21+build.4
 
 modmenu_version=16.0.0-rc.1


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.10`|
|Java|`21`|
|Yarn Mappings|`1.21.10+build.2`|
|NeoForge Yarn Patch|`1.21+build.4`|
|Fabric Loader|`0.17.3`|
|Fabric API|`0.135.0+1.21.10`|
|NeoForge|`21.10.6-beta`|
|Mod Menu|`16.0.0-rc.1`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

