### PR TITLE
[Auto] Update to Minecraft 1.21.1

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -53,7 +53,7 @@
     "fabric-api": "*"
   },
   "recommends": {
-    "fabricloader": ">=0.18.1",
+    "fabricloader": ">=0.18.2",
     "minecraft": "~1.21.9"
   },
   "suggests": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,12 +11,12 @@ archives_name=accessible-step
 enabled_platforms=fabric,neoforge
 
 # Minecraft properties
-minecraft_version=1.21.10
+minecraft_version=1.21.1
 
 # Dependencies
-fabric_loader_version=0.18.1
-fabric_api_version=0.138.3+1.21.10
-neoforge_version=21.10.50-beta
+fabric_loader_version=0.18.2
+fabric_api_version=0.116.7+1.21.1
+neoforge_version=21.1.215
 
-modmenu_version=16.0.0-rc.1
+modmenu_version=11.0.3
 jankson_version=1.2.3


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.1`|
|Java|`21`|
|Fabric Loader|`0.18.2`|
|Fabric API|`0.116.7+1.21.1`|
|NeoForge|`21.1.215`|
|Mod Menu|`11.0.3`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.

