### PR TITLE
[Auto] Update to Minecraft 1.21.11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@
 # Project
 version=2.0.0
 group=co.secretonline.acccessiblestep
-java_version=25
+java_version=21
 
 # Common
-minecraft_version=26.1-pre-3
+minecraft_version=1.21.11
 mod_name=Accessible Step
 mod_author=secret_online
 mod_id=accessible-step
@@ -15,19 +15,19 @@ neoforge_mod_id=accessible_step
 license=MPL-2.0
 credits=secret_online
 description=Walk up full-height blocks without reaching for the jump button.
-minecraft_version_range=[21.6,)
+minecraft_version_range=[1.21.11,)
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=26.1-pre-3-1
+neo_form_version=1.21.11-20251209.172050
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.143.14+26.1
+fabric_version=0.141.3+1.21.11
 fabric_loader_version=0.18.4
 
 modmenu_version=18.0.0-alpha.6
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=26.1.0.0-alpha.15+pre-3
+neoforge_version=21.11.38-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`1.21.11`|
|Java|`21`|
|NeoForm|`1.21.11-20251209.172050`|
|NeoForge|`21.11.38-beta`|
|Fabric Loader|`0.18.4`|
|Fabric API|`0.141.3+1.21.11`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.
