### PR TITLE
[Auto] Update to Minecraft 26.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ group=co.secretonline.acccessiblestep
 java_version=25
 
 # Common
-minecraft_version=26.1
+minecraft_version=26.1.1
 mod_name=Accessible Step
 mod_author=secret_online
 mod_id=accessible-step
@@ -15,19 +15,19 @@ neoforge_mod_id=accessible_step
 license=MPL-2.0
 credits=secret_online
 description=Walk up full-height blocks without reaching for the jump button.
-minecraft_version_range=[26.1,)
+minecraft_version_range=[26.1.1,)
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=26.1-1
+neo_form_version=26.1.1-1
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.144.0+26.1
-fabric_loader_version=0.18.4
+fabric_version=0.145.2+26.1.1
+fabric_loader_version=0.18.6
 
 modmenu_version=18.0.0-alpha.6
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=26.1.0.1-beta
+neoforge_version=26.1.1.0-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`26.1.1`|
|Java|`25`|
|NeoForm|`26.1.1-1`|
|NeoForge|`26.1.1.0-beta`|
|Fabric Loader|`0.18.6`|
|Fabric API|`0.145.2+26.1.1`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.
