### PR TITLE
[Auto] Update to Minecraft 26.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,13 +21,13 @@ minecraft_version_range=[26.1.1,)
 neo_form_version=26.1.1-1
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.145.2+26.1.1
+fabric_version=0.145.3+26.1.1
 fabric_loader_version=0.18.6
 
 modmenu_version=18.0.0-alpha.6
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=26.1.1.0-beta
+neoforge_version=26.1.1.1-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`26.1.1`|
|Java|`25`|
|NeoForm|`26.1.1-1`|
|NeoForge|`26.1.1.1-beta`|
|Fabric Loader|`0.18.6`|
|Fabric API|`0.145.3+26.1.1`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.
