### PR TITLE
[Auto] Update to Minecraft 26.2

### DIFF
--- a/common/src/main/java/co/secretonline/accessiblestep/event/KeyboardHandler.java
+++ b/common/src/main/java/co/secretonline/accessiblestep/event/KeyboardHandler.java
@@ -22,9 +22,8 @@ public class KeyboardHandler {
 
 			String valueColor = (newMode.equals(StepMode.OFF) ? ChatFormatting.RED : ChatFormatting.GREEN).toString();
 			String valueString = valueColor + Component.translatable(newMode.getKey()).getString() + ChatFormatting.RESET;
-			client.getChatListener().handleSystemMessage(Component.translatable("options.generic_value",
-					new Object[] { Component.translatable("options.accessiblestep.mode"), valueString }),
-				true);
+			client.gui.hud.setOverlayMessage(Component.translatable("options.generic_value",
+				Component.translatable("options.accessiblestep.mode"), valueString), false);
 		}
 	}
 }

--- a/common/src/main/java/co/secretonline/accessiblestep/screen/AccessibleStepOptions.java
+++ b/common/src/main/java/co/secretonline/accessiblestep/screen/AccessibleStepOptions.java
@@ -78,7 +78,7 @@ public class AccessibleStepOptions {
 		// Since the world's config has changed, we need to update all of the widgets on
 		// the screen.
 		Minecraft client = Minecraft.getInstance();
-		if (client.screen instanceof AccessibleStepOptionsScreen optionsScreen) {
+		if (client.gui.screen() instanceof AccessibleStepOptionsScreen optionsScreen) {
 			optionsScreen.resetOptionsForWorld();
 		}
 	}
@@ -99,7 +99,7 @@ public class AccessibleStepOptions {
 		// 3. Saving the option uses the handle position, so it saves a different value
 		// to what is shown.
 		Minecraft client = Minecraft.getInstance();
-		if (client.screen instanceof AccessibleStepOptionsScreen optionsScreen) {
+		if (client.gui.screen() instanceof AccessibleStepOptionsScreen optionsScreen) {
 			optionsScreen.rescaleStepHeightSliders();
 		}
 	}

--- a/fabric/src/gametest/java/co/secretonline/accessiblestep/fabric/gametest/client/ClientTestHelper.java
+++ b/fabric/src/gametest/java/co/secretonline/accessiblestep/fabric/gametest/client/ClientTestHelper.java
@@ -35,9 +35,9 @@ public class ClientTestHelper {
 		worldContext.getServer().runOnServer((server) -> {
 			ServerLevel world = server.getLevel(Level.OVERWORLD);
 
-			world.setBlockAndUpdate(blockPos.south(), Blocks.RED_TERRACOTTA.defaultBlockState());
-			world.setBlockAndUpdate(blockPos.south(2).above(1), Blocks.YELLOW_TERRACOTTA.defaultBlockState());
-			world.setBlockAndUpdate(blockPos.south(3).above(2), Blocks.GREEN_TERRACOTTA.defaultBlockState());
+			world.setBlockAndUpdate(blockPos.south(), Blocks.DYED_TERRACOTTA.red().defaultBlockState());
+			world.setBlockAndUpdate(blockPos.south(2).above(1), Blocks.DYED_TERRACOTTA.yellow().defaultBlockState());
+			world.setBlockAndUpdate(blockPos.south(3).above(2), Blocks.DYED_TERRACOTTA.green().defaultBlockState());
 			world.setBlockAndUpdate(blockPos.south(4).above(3), Blocks.BARRIER.defaultBlockState());
 			world.setBlockAndUpdate(blockPos.south(4).above(4), Blocks.BARRIER.defaultBlockState());
 		});

--- a/fabric/src/gametest/java/co/secretonline/accessiblestep/fabric/gametest/client/StepModeAutoJumpTest.java
+++ b/fabric/src/gametest/java/co/secretonline/accessiblestep/fabric/gametest/client/StepModeAutoJumpTest.java
@@ -27,8 +27,8 @@ public class StepModeAutoJumpTest implements FabricClientGameTest {
 			testContext.runOnClient((client) -> {
 				BlockPos endPosition = client.player.blockPosition();
 				Block block = client.player.level().getBlockState(endPosition.below()).getBlock();
-				if (!block.equals(Blocks.YELLOW_TERRACOTTA)) {
-					throw new AssertionError(String.format("Incorrect block. Expected: %s, got %s", Blocks.YELLOW_TERRACOTTA, block));
+				if (!block.equals(Blocks.DYED_TERRACOTTA.yellow())) {
+					throw new AssertionError(String.format("Incorrect block. Expected: %s, got %s", Blocks.DYED_TERRACOTTA.yellow(), block));
 				}
 			});
 		}

--- a/fabric/src/gametest/java/co/secretonline/accessiblestep/fabric/gametest/client/StepModeStepTest.java
+++ b/fabric/src/gametest/java/co/secretonline/accessiblestep/fabric/gametest/client/StepModeStepTest.java
@@ -27,8 +27,8 @@ public class StepModeStepTest implements FabricClientGameTest {
 			testContext.runOnClient((client) -> {
 				BlockPos endPosition = client.player.blockPosition();
 				Block block = client.player.level().getBlockState(endPosition.below()).getBlock();
-				if (!block.equals(Blocks.GREEN_TERRACOTTA)) {
-					throw new AssertionError(String.format("Incorrect block. Expected: %s, got %s", Blocks.GREEN_TERRACOTTA, block));
+				if (!block.equals(Blocks.DYED_TERRACOTTA.green())) {
+					throw new AssertionError(String.format("Incorrect block. Expected: %s, got %s", Blocks.DYED_TERRACOTTA.green(), block));
 				}
 			});
 		}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ group=co.secretonline.acccessiblestep
 java_version=25
 
 # Common
-minecraft_version=26.1.1
+minecraft_version=26.2
 mod_name=Accessible Step
 mod_author=secret_online
 mod_id=accessible-step
@@ -15,19 +15,19 @@ neoforge_mod_id=accessible_step
 license=MPL-2.0
 credits=secret_online
 description=Walk up full-height blocks without reaching for the jump button.
-minecraft_version_range=[26.1.1,)
+minecraft_version_range=[26.2,)
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=26.1.1-1
+neo_form_version=26.2-1
 
 # Fabric, see https://fabricmc.net/develop/ for new versions
-fabric_version=0.145.2+26.1.1
-fabric_loader_version=0.18.6
+fabric_version=0.152.1+26.2
+fabric_loader_version=0.19.3
 
 modmenu_version=18.0.0-alpha.6
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
-neoforge_version=26.1.1.0-beta
+neoforge_version=26.2.0.0-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ neo_form_version=26.2-1
 fabric_version=0.152.1+26.2
 fabric_loader_version=0.19.3
 
-modmenu_version=18.0.0-alpha.6
+modmenu_version=20.0.0-beta.2
 
 # NeoForge, see https://projects.neoforged.net/neoforged/neoforge for new versions
 neoforge_version=26.2.0.0-beta


### PR DESCRIPTION
This PR contains automated updates from the update-minecraft-version workflow.

## Updates

|Component|Version|
|---|---|
|Minecraft|`26.2`|
|Java|`25`|
|NeoForm|`26.2-1`|
|NeoForge|`26.2.0.0-beta`|
|Fabric Loader|`0.19.3`|
|Fabric API|`0.152.1+26.2`|

## Remember to check!

- This update does not do any remapping.
  - It may not compile.
  - It may still crash at run time.
